### PR TITLE
Add gatsby-source-meetup

### DIFF
--- a/clients.md
+++ b/clients.md
@@ -24,7 +24,6 @@ Client libraries make it easier to access the API from your programming language
 * [Must.js](https://github.com/meetup/must.js) A browser client for the Meetup Stream APIs
 * [Node meetup-api](https://npmjs.org/package/meetup-api) A node.js interface to the Meetup API
 
-
 ## Objective-C
 
 * [NSMeetupO2](https://github.com/rodchile/NSMeetUpO2/) A small library that makes easier the Meetup.com API OAuth2 authorization flow for your iOS app.

--- a/clients.md
+++ b/clients.md
@@ -20,8 +20,10 @@ Client libraries make it easier to access the API from your programming language
 ## Javascript
 
 * [angular-meetup](https://github.com/rodrigo-morais/angular-meetup) This Angular component has some services and directives to give some facilities when an app need to communicate with Meetup.com API in an AngularJS project
+* [gatsby-source-meetup](https://github.com/phacks/gatsby-source-meetup) Source plugin for pulling Meetup.com data about a specific Group and the events associated to it into Gatsby applications with GraphQL. 
 * [Must.js](https://github.com/meetup/must.js) A browser client for the Meetup Stream APIs
 * [Node meetup-api](https://npmjs.org/package/meetup-api) A node.js interface to the Meetup API
+
 
 ## Objective-C
 


### PR DESCRIPTION
* [gatsby-source-meetup](https://github.com/phacks/gatsby-source-meetup) Source plugin for pulling Meetup.com data about a specific Group and the events associated to it into Gatsby applications with GraphQL.